### PR TITLE
Adds ID to the textbox control

### DIFF
--- a/Distrib/styledtextbox/styledText.html
+++ b/Distrib/styledtextbox/styledText.html
@@ -2,12 +2,14 @@
     <div class="simple-label" ng-show="{{model.hideLabel}}">{{model.label}}</div>
 
     <input ng-show="model.config.multiLine != 1" ng-model="model.value" ng-change="checkCharLimit()" type="text"
+           id="{{model.alias}}"
            class="umb-editor umb-textstring textstring simple-styledText"
            style="{{model.config.style}}"
            ng-class="{'simple-full' : model.hideLabel}"
            placeholder="{{model.config.placeholder}}" />
 
     <textarea ng-show="model.config.multiLine == 1" ng-model="model.value" ng-change="checkCharLimit()"
+           id="{{model.alias}}"
            class="umb-editor umb-textarea textstring simple-styledText"
            style="{{model.config.style}}"
            ng-class="{'simple-full' : model.hideLabel}"

--- a/StyledTextBox.WebSite/App_Plugins/StyledTextbox/html/styledText.html
+++ b/StyledTextBox.WebSite/App_Plugins/StyledTextbox/html/styledText.html
@@ -2,12 +2,14 @@
     <div class="simple-label" ng-show="{{model.hideLabel}}">{{model.label}}</div>
 
     <input ng-show="model.config.multiLine != 1" ng-model="model.value" ng-change="checkCharLimit()" type="text"
+           id="{{model.alias}}"
            class="umb-editor umb-textstring textstring simple-styledText"
            style="{{model.config.style}}"
            ng-class="{'simple-full' : model.hideLabel}"
            placeholder="{{model.config.placeholder}}" />
 
     <textarea ng-show="model.config.multiLine == 1" ng-model="model.value" ng-change="checkCharLimit()"
+           id="{{model.alias}}"
            class="umb-editor umb-textarea textstring simple-styledText"
            style="{{model.config.style}}"
            ng-class="{'simple-full' : model.hideLabel}"


### PR DESCRIPTION
Adding the ID attribute to the textbox control will hook up the property's label - to set the focus to the control (if clicked on)

> For reference, [Umbraco's textbox.html](https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Web.UI.Client/src/views/propertyeditors/textbox/textbox.html#L2) includes it.

I wasn't sure which `styledText.html` was the main one, so I made the change in both.