### PR TITLE
Also add the classes to the containing div

### DIFF
--- a/StyledTextBox.WebSite/App_Plugins/StyledTextbox/html/styledText.html
+++ b/StyledTextBox.WebSite/App_Plugins/StyledTextbox/html/styledText.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="jumoo.propEditor.styledTextController" class="jumoo-styledText-editor {{model.config.cssclass}}">
+﻿<div ng-controller="jumoo.propEditor.styledTextController" class="jumoo-styledText-editor {{model.config.containercssclass}}">
     <div class="simple-label" ng-if="model.hideLabel">{{model.label}}</div>
 
     <input ng-if="model.config.multiLine != 1" ng-model="model.value" ng-change="checkCharLimit()" type="text"

--- a/StyledTextBox.WebSite/App_Plugins/StyledTextbox/html/styledText.html
+++ b/StyledTextBox.WebSite/App_Plugins/StyledTextbox/html/styledText.html
@@ -1,4 +1,4 @@
-﻿<div ng-controller="jumoo.propEditor.styledTextController" class="jumoo-styledText-editor">
+﻿<div ng-controller="jumoo.propEditor.styledTextController" class="jumoo-styledText-editor {{model.config.cssclass}}">
     <div class="simple-label" ng-if="model.hideLabel">{{model.label}}</div>
 
     <input ng-if="model.config.multiLine != 1" ng-model="model.value" ng-change="checkCharLimit()" type="text"

--- a/StyledTextBox.WebSite/App_Plugins/StyledTextbox/package.manifest
+++ b/StyledTextBox.WebSite/App_Plugins/StyledTextbox/package.manifest
@@ -65,6 +65,7 @@
 				multiLine: 0,
 				style: "font-size: 36px; line-height: 45px; font-weight: bold",
 				cssclass: "",
+				containercssclass: "",
 				charCount: 0,
 				enforceLimit: 0,
 				hideLabel: 0

--- a/StyledTextBox.WebSite/App_Plugins/StyledTextbox/package.manifest
+++ b/StyledTextBox.WebSite/App_Plugins/StyledTextbox/package.manifest
@@ -24,11 +24,17 @@
 						view: "textarea"
 					},
 					{
-						label: "Css Class",
-						description: "Css Class to apply",
+						label: "Input Css Class",
+						description: "Css Class to apply on the input",
 						key: "cssclass",
 						view: "textstring"
 					},
+					{
+						label: "Container Css Class",
+						description: "Css Class to apply on the field container",
+						key: "containercssclass",
+						view: "textstring"
+					},					
 					{
 						label: "Placeholder",
 						description: "Placeholder text to put in box when empty",


### PR DESCRIPTION
Adding the classes to the containing div allows the use of :before and :after. Allowing for icons to be added for example

![image](https://user-images.githubusercontent.com/6782865/54089289-75463400-435f-11e9-9465-2ef929955071.png)
